### PR TITLE
feat: Added env variable to manage the pipeline execution interval in minutes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-API_BASE_URL='https://api.openweathermap.org'
-API_KEY=''
 ZIP_CODE=170001
 COUNTRY_CODE=CO
+
+API_BASE_URL='https://api.openweathermap.org'
+API_KEY=''
+
+PIPELINE_EXECUTION_INTERVAL_IN_MINUTES=5
+
 AZURE_ODBC_CONNECTION_STRING=''

--- a/main.py
+++ b/main.py
@@ -3,10 +3,9 @@ import extract, transform, load
 import datetime
 import schedule
 import time
+import os
 
-
-def main():
-    load_dotenv()
+def etlProcess():
     current_weather_data = extract.extractCurrentWeatherData()
     print(current_weather_data)
     transformed_weather_data: dict[str, float | datetime.datetime] = (
@@ -14,12 +13,23 @@ def main():
     )
     print(f"The transformed data: \n {transformed_weather_data}")
 
-    print("Connection to azure")
     load.upload_data(transformed_weather_data)
 
 
 if __name__ == "__main__":
-    schedule.every(5).seconds.do(main)
+    load_dotenv()
+    PIPELINE_EXECUTION_INTERVAL_IN_MINUTES: str | None = os.getenv('PIPELINE_EXECUTION_INTERVAL_IN_MINUTES')
+    if PIPELINE_EXECUTION_INTERVAL_IN_MINUTES == None:
+        raise Exception('PIPELINE_EXECUTION_INTERVAL_IN_MINUTES can not be empty')
+    
+    try:
+        PIPELINE_EXECUTION_INTERVAL = int(PIPELINE_EXECUTION_INTERVAL_IN_MINUTES)
+    except:
+        raise Exception("There was an error processing the PIPELINE_EXECUTION_INTERVAL_IN_MINUTES env variable. Please only send numbers.")
+        
+    print(f"Sending requests every {PIPELINE_EXECUTION_INTERVAL} minutes")
+    
+    schedule.every(PIPELINE_EXECUTION_INTERVAL).minutes.do(etlProcess)
     while True:
         schedule.run_pending()
         time.sleep(1)


### PR DESCRIPTION
## Description

This pull request adds the `PIPELINE_EXECUTION_INTERVAL_IN_MINUTES` env variable, that can be used in order to define the interval in which the ETL job must re-execute